### PR TITLE
Fix config persistence and propagation

### DIFF
--- a/ConfigObj.py
+++ b/ConfigObj.py
@@ -101,6 +101,8 @@ class ConfigObj:
     #--- Both sceneNum and aName must be strings.
     #----------------------------------------------
     def set_rgbw_values_and_brightness(self, sceneID, sceneName, valueDict, brightnessDict):
+        if sceneID not in self.allScenes:
+            self.allScenes[sceneID] = {}
         self.allScenes[sceneID]["Name"] = sceneName
         self.allScenes[sceneID]["RGBWValues"] = valueDict.copy()
         self.allScenes[sceneID]["Brightness"] = brightnessDict.copy()
@@ -227,6 +229,11 @@ class ConfigObj:
         try:
             with open(filePath, "r") as file:
                 self.config_dict = json.load(file)
+            if "Scenes" in self.config_dict:
+                self.allScenes = self.config_dict["Scenes"]
+            else:
+                self.allScenes = {}
+                self.config_dict["Scenes"] = self.allScenes
 
         except OSError:
             #--- Failed to open file for read so no

--- a/main_board.py
+++ b/main_board.py
@@ -322,6 +322,19 @@ def save_scene_config(sceneID, sceneName, filePath):
 
 
 #----------------------------------------------------------------
+#--- refresh_config_bytes
+#--- Recompute the config JSON from cfgObj and push the updated
+#--- bytes into ledPeripheral so reconnecting centrals get
+#--- the current config rather than the startup snapshot.
+#----------------------------------------------------------------
+def refresh_config_bytes():
+    cfgStr = cfgObj.to_json()
+    cfgBytes = cfgStr.encode('utf-8')
+    cfgBytes += b'\n'
+    ledPeripheral.set_long_string_data(cfgBytes)
+
+
+#----------------------------------------------------------------
 #--- save_scene
 #--- Take the passed in json string, parses out the scene name
 #--- and scene ID and writes the name and all LED values and
@@ -334,52 +347,44 @@ def save_scene(data):
  #       print("Found save scene 1")
         config_file_path = "Scene1.json"
         aName = data["1"]
-        cfgObj.set_scene_name("1", aName)
         save_scene_config("1", aName, config_file_path)
 
     if "2" in data:
         config_file_path = "Scene2.json"
         aName = data["2"]
-        cfgObj.set_scene_name("2", aName)
         save_scene_config("2", aName, config_file_path)
 
     if "3" in data:
         config_file_path = "Scene3.json"
         aName = data["3"]
-        cfgObj.set_scene_name("3", aName)  
         save_scene_config("3", aName, config_file_path)
 
     if "4" in data:
         config_file_path = "Scene4.json"
         aName = data["4"]
-        cfgObj.set_scene_name("4", aName)  
         save_scene_config("4", aName, config_file_path)
 
     if "5" in data:
         config_file_path = "Scene5.json"
         aName = data["5"]
-        cfgObj.set_scene_name("5", aName)  
         save_scene_config("5", aName, config_file_path)
 
     if "6" in data:
         config_file_path = "Scene6.json"
         aName = data["6"]
-        cfgObj.set_scene_name("6", aName)  
         save_scene_config("6", aName, config_file_path)
 
     if "7" in data:
         config_file_path = "Scene7.json"
         aName = data["7"]
-        cfgObj.set_scene_name("7", aName)  
         save_scene_config("7", aName, config_file_path)
 
     if "8" in data:
         config_file_path = "Scene8.json"
         aName = data["8"]
-        cfgObj.set_scene_name("8", aName)  
         save_scene_config("8", aName, config_file_path)
 
-
+    refresh_config_bytes()
 
 
 #----------------------------------------------------------------
@@ -730,6 +735,7 @@ def on_setCtrlType_rx(data):
     cfgObj.set_ctrl_name(ctrlNum, localDict[ctrlNum]['Name'])
     chanNames = localDict[ctrlNum]['ChanNames']
     set_channel_names(ctrlNum, chanNames)
+    refresh_config_bytes()
 
 
 #----------------------------------------------------------------


### PR DESCRIPTION
I noticed that upon saving a scene from the Android device and then refreshing the connection between Android and Pico, the updated config was not being delivered. I identified and fixed three bugs related to how the scenes are persisted, the config gets updated, and how it gets propagated back to Android.

  ---
  1. main_board.py — Removed redundant set_scene_name calls from save_scene
  
  save_scene was calling cfgObj.set_scene_name() before save_scene_config() for each scene slot. This crashed with a KeyError because allScenes starts empty — scenes only enter it when first saved. The name-setting was also redundant since save_scene_config already sets the name via set_rgbw_values_and_brightness. Removed the set_scene_name calls entirely.

  ---
  2. ConfigObj.py — Fix broken allScenes reference after read_config
  
  At class definition time, config_dict["Scenes"] and allScenes point to the same dict object. However, read_config replaces config_dict wholesale with a new dict loaded from JSON, breaking that link. After that point, writes to self.allScenes went into an orphaned dict that write_to_file never read from. Fixed by re-linking self.allScenes = self.config_dict["Scenes"] immediately after loading from file. Also added a guard in set_rgbw_values_and_brightness to create the scene entry if it doesn't exist yet (required for first-time saves of any scene slot).

  ---
  3. main_board.py — Refresh BLE config bytes after config changes
  
  The config bytes delivered to the Android app over BLE are computed once at startup (cfgObj.to_json()) and stored as a fixed snapshot in ledPeripheral. Even with bugs 1 and 2 fixed, a reconnecting Android app would receive the stale startup snapshot rather than the updated config. Added refresh_config_bytes() helper that recomputes the config JSON from the live cfgObj and pushes it to ledPeripheral. Called after every scene save and every controller type/name change.